### PR TITLE
[Fixes] Cull glass pane bottom & top faces

### DIFF
--- a/assets/minecraft/models/block/template_glass_pane_post.json
+++ b/assets/minecraft/models/block/template_glass_pane_post.json
@@ -1,0 +1,15 @@
+{
+    "ambientocclusion": false,
+    "textures": {
+        "particle": "#pane"
+    },
+    "elements": [
+        {   "from": [ 7, 0, 7 ],
+            "to": [ 9, 16, 9 ],
+            "faces": {
+                "down":  { "uv": [  7, 7,  9,  9 ], "texture": "#edge", "cullface": "down" },
+                "up":    { "uv": [  7, 7,  9,  9 ], "texture": "#edge", "cullface": "up" }
+            }
+        }
+    ]
+}

--- a/assets/minecraft/models/block/template_glass_pane_side.json
+++ b/assets/minecraft/models/block/template_glass_pane_side.json
@@ -1,0 +1,18 @@
+{
+    "ambientocclusion": false,
+    "textures": {
+        "particle": "#pane"
+    },
+    "elements": [
+        {   "from": [ 7, 0, 0 ],
+            "to": [ 9, 16, 7 ],
+            "faces": {
+                "down":  { "uv": [  7, 0,  9,  7 ], "texture": "#edge", "cullface": "down" },
+                "up":    { "uv": [  7, 0,  9,  7 ], "texture": "#edge", "cullface": "up" },
+                "north": { "uv": [  7, 0,  9, 16 ], "texture": "#edge", "cullface": "north" },
+                "west":  { "uv": [ 16, 0,  9, 16 ], "texture": "#pane" },
+                "east":  { "uv": [  9, 0, 16, 16 ], "texture": "#pane" }
+            }
+        }
+    ]
+}

--- a/assets/minecraft/models/block/template_glass_pane_side_alt.json
+++ b/assets/minecraft/models/block/template_glass_pane_side_alt.json
@@ -1,0 +1,18 @@
+{
+    "ambientocclusion": false,
+    "textures": {
+        "particle": "#pane"
+    },
+    "elements": [
+        {   "from": [ 7, 0, 9 ],
+            "to": [ 9, 16, 16 ],
+            "faces": {
+                "down":  { "uv": [  7, 0,  9,  7 ], "texture": "#edge", "cullface": "down" },
+                "up":    { "uv": [  7, 0,  9,  7 ], "texture": "#edge", "cullface": "up" },
+                "south": { "uv": [  7, 0,  9, 16 ], "texture": "#edge", "cullface": "south" },
+                "west":  { "uv": [  7, 0,  0, 16 ], "texture": "#pane" },
+                "east":  { "uv": [  0, 0,  7, 16 ], "texture": "#pane" }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Culls the top and bottom faces of glass panes. Not really necessary unless using connected textures.

Without culling:
![2022-03-07_22 46 35](https://user-images.githubusercontent.com/7875618/157162468-f8fb8b51-4b37-4e9e-8cc4-2ce85d4b4376.png)

With culling:
![2022-03-07_22 46 17](https://user-images.githubusercontent.com/7875618/157162470-c0a9c83b-ef81-49c1-83b8-817253301466.png)

