### PR TITLE
Custom block & item models

### DIFF
--- a/assets/minecraft/blockstates/brown_mushroom_block.json
+++ b/assets/minecraft/blockstates/brown_mushroom_block.json
@@ -1,0 +1,114 @@
+{
+    "multipart": [
+        {
+            "apply": { "model": "block/custom/brown_mushroom_cap"},
+            "when": { 
+		"north": true, 
+		"south": true, 
+		"east": true, 
+		"west": true, 
+		"up": true, 
+		"down": true 
+			}
+        },
+        {
+            "apply": { "model": "block/custom/brown_mushroom_pores"},
+            "when": { 
+		"north": false, 
+		"south": false, 
+		"east": false, 
+		"west": false, 
+		"up": false, 
+		"down": false 
+			}
+        },
+        {
+            "apply": { "model": "block/custom/aluminum_ore"},
+            "when": { 
+		"north": true, 
+		"south": false, 
+		"east": false, 
+		"west": false,
+		"up": true, 
+		"down": false 
+			}
+        },
+        {
+            "apply": { "model": "block/custom/aluminum_block"},
+            "when": { 
+		"north": false, 
+		"south": true, 
+		"east": false, 
+		"west": true, 
+		"up": true, 
+		"down": false 
+			}
+        },
+        {
+            "apply": { "model": "block/custom/chetherite_ore"},
+            "when": { 
+		"north": true, 
+		"south": false, 
+		"east": true, 
+		"west": false, 
+		"up": true, 
+		"down": false 
+			}
+        },
+        {
+            "apply": { "model": "block/custom/chetherite_block"},
+            "when": { 
+		"north": false, 
+		"south": true, 
+		"east": false, 
+		"west": false, 
+		"up": true,
+		"down": false 
+			}
+        },
+        {
+            "apply": { "model": "block/custom/titanium_ore"},
+            "when": { 
+		"north": false, 
+		"south": false, 
+		"east": false, 
+		"west": true, 
+		"up": true, 
+		"down": false 
+			}
+        },
+        {
+            "apply": { "model": "block/custom/titanium_block"},
+            "when": { 
+		"north": false, 
+		"south": true, 
+		"east": true, 
+		"west": false, 
+		"up": true, 
+		"down": false 
+			}
+        },
+        {
+            "apply": { "model": "block/custom/uranium_ore"},
+            "when": { 
+		"north": false, 
+		"south": false, 
+		"east": false, 
+		"west": false, 
+		"up": true, 
+		"down": false 
+			}
+        },
+        {
+            "apply": { "model": "block/custom/uranium_block"},
+            "when": { 
+		"north": true, 
+		"south": true, 
+		"east": true, 
+		"west": true, 
+		"up": false, 
+		"down": false 
+			}
+        }
+    ]
+}

--- a/assets/minecraft/models/block/custom/aluminum_block.json
+++ b/assets/minecraft/models/block/custom/aluminum_block.json
@@ -1,0 +1,6 @@
+{
+    "parent": "block/cube_all",
+    "textures": {
+        "all": "block/custom/aluminum_block"
+    }
+}

--- a/assets/minecraft/models/block/custom/aluminum_ore.json
+++ b/assets/minecraft/models/block/custom/aluminum_ore.json
@@ -1,0 +1,6 @@
+{
+    "parent": "block/cube_all",
+    "textures": {
+        "all": "block/custom/aluminum_ore"
+    }
+}

--- a/assets/minecraft/models/block/custom/brown_mushroom_cap.json
+++ b/assets/minecraft/models/block/custom/brown_mushroom_cap.json
@@ -1,0 +1,6 @@
+{
+    "parent": "block/cube_all",
+    "textures": {
+        "all": "block/brown_mushroom_block"
+    }
+}

--- a/assets/minecraft/models/block/custom/brown_mushroom_pores.json
+++ b/assets/minecraft/models/block/custom/brown_mushroom_pores.json
@@ -1,0 +1,6 @@
+{
+    "parent": "block/cube_all",
+    "textures": {
+        "all": "block/mushroom_block_inside"
+    }
+}

--- a/assets/minecraft/models/block/custom/chetherite_block.json
+++ b/assets/minecraft/models/block/custom/chetherite_block.json
@@ -1,0 +1,6 @@
+{
+    "parent": "block/cube_all",
+    "textures": {
+        "all": "block/custom/chetherite_block"
+    }
+}

--- a/assets/minecraft/models/block/custom/chetherite_ore.json
+++ b/assets/minecraft/models/block/custom/chetherite_ore.json
@@ -1,0 +1,6 @@
+{
+    "parent": "block/cube_all",
+    "textures": {
+        "all": "block/custom/chetherite_ore"
+    }
+}

--- a/assets/minecraft/models/block/custom/titanium_block.json
+++ b/assets/minecraft/models/block/custom/titanium_block.json
@@ -1,0 +1,6 @@
+{
+    "parent": "block/cube_all",
+    "textures": {
+        "all": "block/custom/titanium_block"
+    }
+}

--- a/assets/minecraft/models/block/custom/titanium_ore.json
+++ b/assets/minecraft/models/block/custom/titanium_ore.json
@@ -1,0 +1,6 @@
+{
+    "parent": "block/cube_all",
+    "textures": {
+        "all": "block/custom/titanium_ore"
+    }
+}

--- a/assets/minecraft/models/block/custom/uranium_block.json
+++ b/assets/minecraft/models/block/custom/uranium_block.json
@@ -1,0 +1,6 @@
+{
+    "parent": "block/cube_all",
+    "textures": {
+        "all": "block/custom/uranium_block"
+    }
+}

--- a/assets/minecraft/models/block/custom/uranium_ore.json
+++ b/assets/minecraft/models/block/custom/uranium_ore.json
@@ -1,0 +1,6 @@
+{
+    "parent": "block/cube_all",
+    "textures": {
+        "all": "block/custom/uranium_ore"
+    }
+}

--- a/assets/minecraft/models/item/bow.json
+++ b/assets/minecraft/models/item/bow.json
@@ -1,0 +1,102 @@
+{
+    "parent": "item/generated",
+    "textures": {
+        "layer0": "item/bow"
+    },
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [
+                -80,
+                260,
+                -40
+            ],
+            "translation": [
+                -1,
+                -2,
+                2.5
+            ],
+            "scale": [
+                0.9,
+                0.9,
+                0.9
+            ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [
+                -80,
+                -280,
+                40
+            ],
+            "translation": [
+                -1,
+                -2,
+                2.5
+            ],
+            "scale": [
+                0.9,
+                0.9,
+                0.9
+            ]
+        },
+        "firstperson_righthand": {
+            "rotation": [
+                0,
+                -90,
+                25
+            ],
+            "translation": [
+                1.13,
+                3.2,
+                1.13
+            ],
+            "scale": [
+                0.68,
+                0.68,
+                0.68
+            ]
+        },
+        "firstperson_lefthand": {
+            "rotation": [
+                0,
+                90,
+                -25
+            ],
+            "translation": [
+                1.13,
+                3.2,
+                1.13
+            ],
+            "scale": [
+                0.68,
+                0.68,
+                0.68
+            ]
+        }
+    },
+    "overrides": [
+        {
+            "predicate": {
+                "pulling": 1
+            },
+            "model": "item/bow_pulling_0"
+        },
+        {
+            "predicate": {
+                "pulling": 1,
+                "pull": 0.65
+            },
+            "model": "item/bow_pulling_1"
+        },
+        {
+            "predicate": {
+                "pulling": 1,
+                "pull": 0.9
+            },
+            "model": "item/bow_pulling_2"
+        },
+        { "predicate": { "custom_model_data": 1 }, "model": "item/custom/pistol" },
+        { "predicate": { "custom_model_data": 2 }, "model": "item/custom/rifle" },
+        { "predicate": { "custom_model_data": 3 }, "model": "item/custom/sniper" },
+        { "predicate": { "custom_model_data": 4 }, "model": "item/custom/cannon" }
+    ]
+}

--- a/assets/minecraft/models/item/custom/aluminum.json
+++ b/assets/minecraft/models/item/custom/aluminum.json
@@ -1,0 +1,6 @@
+{
+    "parent": "item/generated",
+    "textures": {
+        "layer0": "item/custom/aluminum"
+    }
+}

--- a/assets/minecraft/models/item/custom/aluminum_block.json
+++ b/assets/minecraft/models/item/custom/aluminum_block.json
@@ -1,0 +1,3 @@
+{
+    "parent": "block/custom/aluminum_block"
+}

--- a/assets/minecraft/models/item/custom/aluminum_ore.json
+++ b/assets/minecraft/models/item/custom/aluminum_ore.json
@@ -1,0 +1,3 @@
+{
+    "parent": "block/custom/aluminum_ore"
+}

--- a/assets/minecraft/models/item/custom/battery_a.json
+++ b/assets/minecraft/models/item/custom/battery_a.json
@@ -1,0 +1,23 @@
+{
+    "parent": "builtin/generated",
+    "textures": {
+        "layer0": "item/custom/battery_a"
+    },
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 0, 0, 0 ],
+            "scale": [ 0.25, 0.25, 0.25 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 0, 0, 0 ],
+            "scale": [ 0.25, 0.25, 0.25 ]
+        },
+        "ground": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 0, 0, 0 ],
+            "scale": [ 0.25, 0.25, 0.25 ]
+        }
+	}
+}

--- a/assets/minecraft/models/item/custom/battery_g.json
+++ b/assets/minecraft/models/item/custom/battery_g.json
@@ -1,0 +1,23 @@
+{
+    "parent": "builtin/generated",
+    "textures": {
+        "layer0": "item/custom/batteries/battery_g"
+    },
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 0, 0, 0 ],
+            "scale": [ 0.50, 0.50, 0.50 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 0, 0, 0 ],
+            "scale": [ 0.50, 0.50, 0.50 ]
+        },
+        "ground": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 0, 0, 0 ],
+            "scale": [ 0.50, 0.50, 0.50 ]
+        }
+	}
+}

--- a/assets/minecraft/models/item/custom/battery_m.json
+++ b/assets/minecraft/models/item/custom/battery_m.json
@@ -1,0 +1,23 @@
+{
+    "parent": "builtin/generated",
+    "textures": {
+        "layer0": "item/custom/battery_m"
+    },
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 0, 0, 0 ],
+            "scale": [ 0.30, 0.30, 0.30 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 0, 0, 0 ],
+            "scale": [ 0.30, 0.30, 0.30 ]
+        },
+        "ground": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 0, 0, 0 ],
+            "scale": [ 0.30, 0.30, 0.30 ]
+        }
+	}
+}

--- a/assets/minecraft/models/item/custom/blue_energy_sword.json
+++ b/assets/minecraft/models/item/custom/blue_energy_sword.json
@@ -1,0 +1,33 @@
+{
+    "parent": "item/handheld",
+    "textures": {
+        "layer0": "item/custom/blue_energy_sword"
+    },
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ 45, 90, 0 ],
+            "translation": [ 0, 6, 2 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ -45, 90, 0 ],
+            "translation": [ 0, 6, 2 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        },
+		"firstperson_righthand": {
+            "rotation": [ -25, -70, 25 ],
+            "translation": [ -3, 5, 2 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        },
+        "firstperson_lefthand": {
+            "rotation": [ -25, 70, -25 ],
+            "translation": [ -3, 5, 2 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        },
+        "ground": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 4, 4, 2],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        }
+    }
+}

--- a/assets/minecraft/models/item/custom/blue_energy_sword_blocking.json
+++ b/assets/minecraft/models/item/custom/blue_energy_sword_blocking.json
@@ -1,0 +1,25 @@
+{
+    "parent": "item/custom/blue_energy_sword",
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ 35, 100, 0 ],
+            "translation": [ -0.5, 6, 1 ],
+            "scale": [ 1.3, 1.3, 1.0 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ -35, 100, 0 ],
+            "translation": [ 0.5, 6, 3 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        },
+		"firstperson_righthand": {
+            "rotation": [ -25, -50, 90 ],
+            "translation": [ -7, 6, 3 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        },
+        "firstperson_lefthand": {
+            "rotation": [ -25, 130, -90 ],
+            "translation": [ -7, 6, 3 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        }
+    }
+}

--- a/assets/minecraft/models/item/custom/cannon.json
+++ b/assets/minecraft/models/item/custom/cannon.json
@@ -1,0 +1,18 @@
+{
+    "parent": "item/bow",
+    "textures": {
+        "layer0": "item/custom/cannon"
+    },
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ -45, -90, 0 ],
+            "translation": [ 0, 2, -1 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ -45, 90, 0 ],
+            "translation": [ 0, 2, -1 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        }
+    }
+}

--- a/assets/minecraft/models/item/custom/carbon_dioxide_gas_canister.json
+++ b/assets/minecraft/models/item/custom/carbon_dioxide_gas_canister.json
@@ -1,0 +1,6 @@
+{
+    "parent": "builtin/generated",
+    "textures": {
+        "layer0": "item/custom/carbon_dioxide_gas_canister"
+    }
+}

--- a/assets/minecraft/models/item/custom/chetherite.json
+++ b/assets/minecraft/models/item/custom/chetherite.json
@@ -1,0 +1,6 @@
+{
+    "parent": "item/generated",
+    "textures": {
+        "layer0": "item/custom/chetherite"
+    }
+}

--- a/assets/minecraft/models/item/custom/chetherite_block.json
+++ b/assets/minecraft/models/item/custom/chetherite_block.json
@@ -1,0 +1,3 @@
+{
+    "parent": "block/custom/chetherite_block"
+}

--- a/assets/minecraft/models/item/custom/chetherite_ore.json
+++ b/assets/minecraft/models/item/custom/chetherite_ore.json
@@ -1,0 +1,3 @@
+{
+    "parent": "block/custom/chetherite_ore"
+}

--- a/assets/minecraft/models/item/custom/detonator.json
+++ b/assets/minecraft/models/item/custom/detonator.json
@@ -1,0 +1,6 @@
+{
+    "parent": "builtin/generated",
+    "textures": {
+        "layer0": "item/custom/detonator"
+    }
+}

--- a/assets/minecraft/models/item/custom/empty_gas_canister.json
+++ b/assets/minecraft/models/item/custom/empty_gas_canister.json
@@ -1,0 +1,6 @@
+{
+    "parent": "builtin/generated",
+    "textures": {
+        "layer0": "item/custom/empty_gas_canister"
+    }
+}

--- a/assets/minecraft/models/item/custom/environment_module.json
+++ b/assets/minecraft/models/item/custom/environment_module.json
@@ -1,0 +1,6 @@
+{
+    "parent": "item/generated",
+    "textures": {
+        "layer0": "item/custom/environment_module"
+    }
+}

--- a/assets/minecraft/models/item/custom/green_energy_sword.json
+++ b/assets/minecraft/models/item/custom/green_energy_sword.json
@@ -1,0 +1,33 @@
+{
+    "parent": "item/handheld",
+    "textures": {
+        "layer0": "item/custom/green_energy_sword"
+    },
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ 45, 90, 0 ],
+            "translation": [ 0, 6, 2 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ -45, 90, 0 ],
+            "translation": [ 0, 6, 2 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        },
+		"firstperson_righthand": {
+            "rotation": [ -25, -70, 25 ],
+            "translation": [ -3, 5, 2 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        },
+        "firstperson_lefthand": {
+            "rotation": [ -25, 70, -25 ],
+            "translation": [ -3, 5, 2 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        },
+        "ground": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 4, 4, 2],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        }
+    }
+}

--- a/assets/minecraft/models/item/custom/green_energy_sword_blocking.json
+++ b/assets/minecraft/models/item/custom/green_energy_sword_blocking.json
@@ -1,0 +1,25 @@
+{
+    "parent": "item/custom/green_energy_sword",
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ 35, 100, 0 ],
+            "translation": [ -0.5, 6, 1 ],
+            "scale": [ 1.3, 1.3, 1.0 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ -35, 100, 0 ],
+            "translation": [ 0.5, 6, 3 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        },
+		"firstperson_righthand": {
+            "rotation": [ -25, -50, 90 ],
+            "translation": [ -7, 6, 3 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        },
+        "firstperson_lefthand": {
+            "rotation": [ -25, 130, -90 ],
+            "translation": [ -7, 6, 3 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        }
+    }
+}

--- a/assets/minecraft/models/item/custom/helium_gas_canister.json
+++ b/assets/minecraft/models/item/custom/helium_gas_canister.json
@@ -1,0 +1,6 @@
+{
+    "parent": "builtin/generated",
+    "textures": {
+        "layer0": "item/custom/helium_gas_canister"
+    }
+}

--- a/assets/minecraft/models/item/custom/hydrogen_gas_canister.json
+++ b/assets/minecraft/models/item/custom/hydrogen_gas_canister.json
@@ -1,0 +1,6 @@
+{
+    "parent": "builtin/generated",
+    "textures": {
+        "layer0": "item/custom/hydrogen_gas_canister"
+    }
+}

--- a/assets/minecraft/models/item/custom/night_vision_module.json
+++ b/assets/minecraft/models/item/custom/night_vision_module.json
@@ -1,0 +1,6 @@
+{
+    "parent": "item/generated",
+    "textures": {
+        "layer0": "item/custom/night_vision_module"
+    }
+}

--- a/assets/minecraft/models/item/custom/nitrogen_gas_canister.json
+++ b/assets/minecraft/models/item/custom/nitrogen_gas_canister.json
@@ -1,0 +1,6 @@
+{
+    "parent": "builtin/generated",
+    "textures": {
+        "layer0": "item/custom/nitrogen_gas_canister"
+    }
+}

--- a/assets/minecraft/models/item/custom/orange_energy_sword.json
+++ b/assets/minecraft/models/item/custom/orange_energy_sword.json
@@ -1,0 +1,33 @@
+{
+    "parent": "item/handheld",
+    "textures": {
+        "layer0": "item/custom/orange_energy_sword"
+    },
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ 45, 90, 0 ],
+            "translation": [ 0, 6, 2 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ -45, 90, 0 ],
+            "translation": [ 0, 6, 2 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        },
+		"firstperson_righthand": {
+            "rotation": [ -25, -70, 25 ],
+            "translation": [ -3, 5, 2 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        },
+        "firstperson_lefthand": {
+            "rotation": [ -25, 70, -25 ],
+            "translation": [ -3, 5, 2 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        },
+        "ground": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 4, 4, 2],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        }
+    }
+}

--- a/assets/minecraft/models/item/custom/orange_energy_sword_blocking.json
+++ b/assets/minecraft/models/item/custom/orange_energy_sword_blocking.json
@@ -1,0 +1,25 @@
+{
+    "parent": "item/custom/orange_energy_sword",
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ 35, 100, 0 ],
+            "translation": [ -0.5, 6, 1 ],
+            "scale": [ 1.3, 1.3, 1.0 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ -35, 100, 0 ],
+            "translation": [ 0.5, 6, 3 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        },
+		"firstperson_righthand": {
+            "rotation": [ -25, -50, 90 ],
+            "translation": [ -7, 6, 3 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        },
+        "firstperson_lefthand": {
+            "rotation": [ -25, 130, -90 ],
+            "translation": [ -7, 6, 3 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        }
+    }
+}

--- a/assets/minecraft/models/item/custom/oxygen_gas_canister.json
+++ b/assets/minecraft/models/item/custom/oxygen_gas_canister.json
@@ -1,0 +1,6 @@
+{
+    "parent": "builtin/generated",
+    "textures": {
+        "layer0": "item/custom/oxygen_gas_canister"
+    }
+}

--- a/assets/minecraft/models/item/custom/pistol.json
+++ b/assets/minecraft/models/item/custom/pistol.json
@@ -1,0 +1,18 @@
+{
+    "parent": "item/bow",
+    "textures": {
+        "layer0": "item/custom/pistol"
+    },
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ -45, -90, 0 ],
+            "translation": [ 0, 1, -1 ],
+            "scale": [ 0.7, 0.7, 0.7 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ -45, 90, 0 ],
+            "translation": [ 0, 1, -1 ],
+            "scale": [ 0.7, 0.7, 0.7 ]
+        }
+    }
+}

--- a/assets/minecraft/models/item/custom/power_drill.json
+++ b/assets/minecraft/models/item/custom/power_drill.json
@@ -1,0 +1,18 @@
+{
+    "parent": "item/handheld",
+    "textures": {
+        "layer0": "item/custom/power_drill"
+    },
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ 230, 90, 0 ],
+            "translation": [ 0, -2, -4 ],
+            "scale": [ 1, 1, 1 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ -40, 90, 0 ],
+            "translation": [ 0, -2, -4 ],
+            "scale": [ 1, 1, 1 ]
+        }
+	}
+}

--- a/assets/minecraft/models/item/custom/pressure_field_module.json
+++ b/assets/minecraft/models/item/custom/pressure_field_module.json
@@ -1,0 +1,6 @@
+{
+    "parent": "item/generated",
+    "textures": {
+        "layer0": "item/custom/pressure_field_module"
+    }
+}

--- a/assets/minecraft/models/item/custom/purple_energy_sword.json
+++ b/assets/minecraft/models/item/custom/purple_energy_sword.json
@@ -1,0 +1,33 @@
+{
+    "parent": "item/handheld",
+    "textures": {
+        "layer0": "item/custom/purple_energy_sword"
+    },
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ 45, 90, 0 ],
+            "translation": [ 0, 6, 2 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ -45, 90, 0 ],
+            "translation": [ 0, 6, 2 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        },
+		"firstperson_righthand": {
+            "rotation": [ -25, -70, 25 ],
+            "translation": [ -3, 5, 2 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        },
+        "firstperson_lefthand": {
+            "rotation": [ -25, 70, -25 ],
+            "translation": [ -3, 5, 2 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        },
+        "ground": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 4, 4, 2],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        }
+    }
+}

--- a/assets/minecraft/models/item/custom/purple_energy_sword_blocking.json
+++ b/assets/minecraft/models/item/custom/purple_energy_sword_blocking.json
@@ -1,0 +1,25 @@
+{
+    "parent": "item/custom/purple_energy_sword",
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ 35, 100, 0 ],
+            "translation": [ -0.5, 6, 1 ],
+            "scale": [ 1.3, 1.3, 1.0 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ -35, 100, 0 ],
+            "translation": [ 0.5, 6, 3 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        },
+		"firstperson_righthand": {
+            "rotation": [ -25, -50, 90 ],
+            "translation": [ -7, 6, 3 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        },
+        "firstperson_lefthand": {
+            "rotation": [ -25, 130, -90 ],
+            "translation": [ -7, 6, 3 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        }
+    }
+}

--- a/assets/minecraft/models/item/custom/red_energy_sword.json
+++ b/assets/minecraft/models/item/custom/red_energy_sword.json
@@ -1,0 +1,33 @@
+{
+    "parent": "item/handheld",
+    "textures": {
+        "layer0": "item/custom/red_energy_sword"
+    },
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ 45, 90, 0 ],
+            "translation": [ 0, 6, 2 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ -45, 90, 0 ],
+            "translation": [ 0, 6, 2 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        },
+		"firstperson_righthand": {
+            "rotation": [ -25, -70, 25 ],
+            "translation": [ -3, 5, 2 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        },
+        "firstperson_lefthand": {
+            "rotation": [ -25, 70, -25 ],
+            "translation": [ -3, 5, 2 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        },
+        "ground": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 4, 4, 2],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        }
+    }
+}

--- a/assets/minecraft/models/item/custom/red_energy_sword_blocking.json
+++ b/assets/minecraft/models/item/custom/red_energy_sword_blocking.json
@@ -1,0 +1,25 @@
+{
+    "parent": "item/custom/red_energy_sword",
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ 35, 100, 0 ],
+            "translation": [ -0.5, 6, 1 ],
+            "scale": [ 1.3, 1.3, 1.0 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ -35, 100, 0 ],
+            "translation": [ 0.5, 6, 3 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        },
+		"firstperson_righthand": {
+            "rotation": [ -25, -50, 90 ],
+            "translation": [ -7, 6, 3 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        },
+        "firstperson_lefthand": {
+            "rotation": [ -25, 130, -90 ],
+            "translation": [ -7, 6, 3 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        }
+    }
+}

--- a/assets/minecraft/models/item/custom/rifle.json
+++ b/assets/minecraft/models/item/custom/rifle.json
@@ -1,0 +1,16 @@
+{
+    "parent": "item/handheld",
+    "textures": {
+        "layer0": "item/custom/rifle"
+    },
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ -45, -90, 0 ],
+            "translation": [ 0, 3, 2 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ -45, 90, 0 ],
+            "translation": [ 0, 3, 2 ]
+        }
+    }
+}

--- a/assets/minecraft/models/item/custom/rocket_boosting_module.json
+++ b/assets/minecraft/models/item/custom/rocket_boosting_module.json
@@ -1,0 +1,6 @@
+{
+    "parent": "item/generated",
+    "textures": {
+        "layer0": "item/custom/rocket_boosting_module"
+    }
+}

--- a/assets/minecraft/models/item/custom/shock_absorbing_module.json
+++ b/assets/minecraft/models/item/custom/shock_absorbing_module.json
@@ -1,0 +1,6 @@
+{
+    "parent": "item/generated",
+    "textures": {
+        "layer0": "item/custom/shock_absorbing_module"
+    }
+}

--- a/assets/minecraft/models/item/custom/sniper.json
+++ b/assets/minecraft/models/item/custom/sniper.json
@@ -1,0 +1,18 @@
+{
+    "parent": "item/bow",
+    "textures": {
+        "layer0": "item/custom/sniper"
+    },
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ -45, -90, 0 ],
+            "translation": [ 0, 4, 0 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ -45, 90, 0 ],
+            "translation": [ 0, 4, 0 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        }
+    }
+}

--- a/assets/minecraft/models/item/custom/speed_boosting_module.json
+++ b/assets/minecraft/models/item/custom/speed_boosting_module.json
@@ -1,0 +1,6 @@
+{
+    "parent": "item/generated",
+    "textures": {
+        "layer0": "item/custom/speed_boosting_module"
+    }
+}

--- a/assets/minecraft/models/item/custom/titanium.json
+++ b/assets/minecraft/models/item/custom/titanium.json
@@ -1,0 +1,6 @@
+{
+    "parent": "item/generated",
+    "textures": {
+        "layer0": "item/custom/titanium"
+    }
+}

--- a/assets/minecraft/models/item/custom/titanium_block.json
+++ b/assets/minecraft/models/item/custom/titanium_block.json
@@ -1,0 +1,3 @@
+{
+    "parent": "block/custom/titanium_block"
+}

--- a/assets/minecraft/models/item/custom/titanium_ore.json
+++ b/assets/minecraft/models/item/custom/titanium_ore.json
@@ -1,0 +1,3 @@
+{
+    "parent": "block/custom/titanium_ore"
+}

--- a/assets/minecraft/models/item/custom/uranium.json
+++ b/assets/minecraft/models/item/custom/uranium.json
@@ -1,0 +1,6 @@
+{
+    "parent": "item/generated",
+    "textures": {
+        "layer0": "item/custom/uranium"
+    }
+}

--- a/assets/minecraft/models/item/custom/uranium_block.json
+++ b/assets/minecraft/models/item/custom/uranium_block.json
@@ -1,0 +1,3 @@
+{
+    "parent": "block/custom/uranium_block"
+}

--- a/assets/minecraft/models/item/custom/uranium_ore.json
+++ b/assets/minecraft/models/item/custom/uranium_ore.json
@@ -1,0 +1,3 @@
+{
+    "parent": "block/custom/uranium_ore"
+}

--- a/assets/minecraft/models/item/custom/yellow_energy_sword.json
+++ b/assets/minecraft/models/item/custom/yellow_energy_sword.json
@@ -1,0 +1,33 @@
+{
+    "parent": "item/handheld",
+    "textures": {
+        "layer0": "item/custom/yellow_energy_sword"
+    },
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ 45, 90, 0 ],
+            "translation": [ 0, 6, 2 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ -45, 90, 0 ],
+            "translation": [ 0, 6, 2 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        },
+		"firstperson_righthand": {
+            "rotation": [ -25, -70, 25 ],
+            "translation": [ -3, 5, 2 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        },
+        "firstperson_lefthand": {
+            "rotation": [ -25, 70, -25 ],
+            "translation": [ -3, 5, 2 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        },
+        "ground": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 4, 4, 2],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        }
+    }
+}

--- a/assets/minecraft/models/item/custom/yellow_energy_sword_blocking.json
+++ b/assets/minecraft/models/item/custom/yellow_energy_sword_blocking.json
@@ -1,0 +1,25 @@
+{
+    "parent": "item/custom/yellow_energy_sword",
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ 35, 100, 0 ],
+            "translation": [ -0.5, 6, 1 ],
+            "scale": [ 1.3, 1.3, 1.0 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ -35, 100, 0 ],
+            "translation": [ 0.5, 6, 3 ],
+            "scale": [ 1.3, 1.3, 1.3 ]
+        },
+		"firstperson_righthand": {
+            "rotation": [ -25, -50, 90 ],
+            "translation": [ -7, 6, 3 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        },
+        "firstperson_lefthand": {
+            "rotation": [ -25, 130, -90 ],
+            "translation": [ -7, 6, 3 ],
+            "scale": [ 0.86, 0.86, 0.86 ]
+        }
+    }
+}

--- a/assets/minecraft/models/item/diamond_pickaxe.json
+++ b/assets/minecraft/models/item/diamond_pickaxe.json
@@ -1,0 +1,9 @@
+{
+    "parent": "item/handheld",
+    "textures": {
+        "layer0": "item/diamond_pickaxe"
+    },
+    "overrides": [
+        { "predicate": { "custom_model_data": 1 }, "model": "item/custom/power_drill" }
+    ]
+}

--- a/assets/minecraft/models/item/flint_and_steel.json
+++ b/assets/minecraft/models/item/flint_and_steel.json
@@ -1,0 +1,14 @@
+{
+    "parent": "item/generated",
+    "textures": {
+        "layer0": "item/flint_and_steel"
+    },
+    "overrides": [
+        { "predicate": { "custom_model_data": 1 }, "model": "item/custom/shock_absorbing_module" },
+        { "predicate": { "custom_model_data": 2 }, "model": "item/custom/speed_boosting_module" },
+        { "predicate": { "custom_model_data": 3 }, "model": "item/custom/rocket_boosting_module" },
+        { "predicate": { "custom_model_data": 4 }, "model": "item/custom/night_vision_module" },
+        { "predicate": { "custom_model_data": 5 }, "model": "item/custom/environment_module" },
+        { "predicate": { "custom_model_data": 6 }, "model": "item/custom/pressure_field_module" }
+    ]
+}

--- a/assets/minecraft/models/item/iron_block.json
+++ b/assets/minecraft/models/item/iron_block.json
@@ -1,0 +1,9 @@
+{
+    "parent": "block/iron_block",
+    "overrides": [
+        { "predicate": { "custom_model_data": 2 }, "model": "item/custom/aluminum_block" },
+        { "predicate": { "custom_model_data": 3 }, "model": "item/custom/chetherite_block" },
+        { "predicate": { "custom_model_data": 4 }, "model": "item/custom/titanium_block" },
+        { "predicate": { "custom_model_data": 5 }, "model": "item/custom/uranium_block" }
+    ]
+}

--- a/assets/minecraft/models/item/iron_block.json
+++ b/assets/minecraft/models/item/iron_block.json
@@ -1,9 +1,9 @@
 {
     "parent": "block/iron_block",
     "overrides": [
-        { "predicate": { "custom_model_data": 2 }, "model": "item/custom/aluminum_block" },
-        { "predicate": { "custom_model_data": 3 }, "model": "item/custom/chetherite_block" },
-        { "predicate": { "custom_model_data": 4 }, "model": "item/custom/titanium_block" },
-        { "predicate": { "custom_model_data": 5 }, "model": "item/custom/uranium_block" }
+        { "predicate": { "custom_model_data": 1 }, "model": "item/custom/aluminum_block" },
+        { "predicate": { "custom_model_data": 2 }, "model": "item/custom/chetherite_block" },
+        { "predicate": { "custom_model_data": 3 }, "model": "item/custom/titanium_block" },
+        { "predicate": { "custom_model_data": 4 }, "model": "item/custom/uranium_block" }
     ]
 }

--- a/assets/minecraft/models/item/iron_ingot.json
+++ b/assets/minecraft/models/item/iron_ingot.json
@@ -1,0 +1,12 @@
+{
+    "parent": "item/generated",
+    "textures": {
+        "layer0": "item/iron_ingot"
+    },
+    "overrides": [
+        { "predicate": { "custom_model_data": 2 }, "model": "item/custom/aluminum" },
+        { "predicate": { "custom_model_data": 3 }, "model": "item/custom/chetherite" },
+        { "predicate": { "custom_model_data": 4 }, "model": "item/custom/titanium" },
+        { "predicate": { "custom_model_data": 5 }, "model": "item/custom/uranium" }
+    ]
+}

--- a/assets/minecraft/models/item/iron_ingot.json
+++ b/assets/minecraft/models/item/iron_ingot.json
@@ -4,9 +4,9 @@
         "layer0": "item/iron_ingot"
     },
     "overrides": [
-        { "predicate": { "custom_model_data": 2 }, "model": "item/custom/aluminum" },
-        { "predicate": { "custom_model_data": 3 }, "model": "item/custom/chetherite" },
-        { "predicate": { "custom_model_data": 4 }, "model": "item/custom/titanium" },
-        { "predicate": { "custom_model_data": 5 }, "model": "item/custom/uranium" }
+        { "predicate": { "custom_model_data": 1 }, "model": "item/custom/aluminum" },
+        { "predicate": { "custom_model_data": 2 }, "model": "item/custom/chetherite" },
+        { "predicate": { "custom_model_data": 3 }, "model": "item/custom/titanium" },
+        { "predicate": { "custom_model_data": 4 }, "model": "item/custom/uranium" }
     ]
 }

--- a/assets/minecraft/models/item/iron_ore.json
+++ b/assets/minecraft/models/item/iron_ore.json
@@ -1,0 +1,9 @@
+{
+    "parent": "block/iron_ore",
+    "overrides": [
+        { "predicate": { "custom_model_data": 2 }, "model": "item/custom/aluminum_ore" },
+        { "predicate": { "custom_model_data": 3 }, "model": "item/custom/chetherite_ore" },
+        { "predicate": { "custom_model_data": 4 }, "model": "item/custom/titanium_ore" },
+        { "predicate": { "custom_model_data": 5 }, "model": "item/custom/uranium_ore" }
+    ]
+}

--- a/assets/minecraft/models/item/iron_ore.json
+++ b/assets/minecraft/models/item/iron_ore.json
@@ -1,9 +1,9 @@
 {
     "parent": "block/iron_ore",
     "overrides": [
-        { "predicate": { "custom_model_data": 2 }, "model": "item/custom/aluminum_ore" },
-        { "predicate": { "custom_model_data": 3 }, "model": "item/custom/chetherite_ore" },
-        { "predicate": { "custom_model_data": 4 }, "model": "item/custom/titanium_ore" },
-        { "predicate": { "custom_model_data": 5 }, "model": "item/custom/uranium_ore" }
+        { "predicate": { "custom_model_data": 1 }, "model": "item/custom/aluminum_ore" },
+        { "predicate": { "custom_model_data": 2 }, "model": "item/custom/chetherite_ore" },
+        { "predicate": { "custom_model_data": 3 }, "model": "item/custom/titanium_ore" },
+        { "predicate": { "custom_model_data": 4 }, "model": "item/custom/uranium_ore" }
     ]
 }

--- a/assets/minecraft/models/item/shears.json
+++ b/assets/minecraft/models/item/shears.json
@@ -1,0 +1,9 @@
+{
+    "parent": "item/generated",
+    "textures": {
+        "layer0": "item/shears"
+    },
+    "overrides": [
+        { "predicate": { "custom_model_data": 1 }, "model": "item/custom/detonator" }
+    ]
+}

--- a/assets/minecraft/models/item/shield.json
+++ b/assets/minecraft/models/item/shield.json
@@ -1,0 +1,58 @@
+{
+    "parent": "builtin/entity",
+    "textures": {
+        "particle": "block/dark_oak_planks"
+    },
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ 0, 90, 0 ],
+            "translation": [ 10, 6, -4 ],
+            "scale": [ 1, 1, 1 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ 0, 90, 0 ],
+            "translation": [ 10, 6, 12 ],
+            "scale": [ 1, 1, 1 ]
+        },
+        "firstperson_righthand": {
+            "rotation": [ 0, 180, 5 ],
+            "translation": [ -10, 2, -10 ],
+            "scale": [ 1.25, 1.25, 1.25 ]
+        },
+        "firstperson_lefthand": {
+            "rotation": [ 0, 180, 5 ],
+            "translation": [ 10, 0, -10 ],
+            "scale": [ 1.25, 1.25, 1.25 ]
+        },
+        "gui": {
+            "rotation": [ 15, -25, -5 ],
+            "translation": [ 2, 3, 0 ],
+            "scale": [ 0.65, 0.65, 0.65 ]
+        },
+        "fixed": {
+            "rotation": [ 0, 180, 0 ],
+            "translation": [ -2, 4, -5],
+            "scale":[ 0.5, 0.5, 0.5]
+        },
+        "ground": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 4, 4, 2],
+            "scale":[ 0.25, 0.25, 0.25]
+        }
+    },
+    "overrides": [
+        { "predicate": { "custom_model_data": 0, "blocking": 1 }, "model": "item/shield_blocking" },
+        { "predicate": { "custom_model_data": 1, "blocking": 0 }, "model": "item/custom/blue_energy_sword" },
+        { "predicate": { "custom_model_data": 1, "blocking": 1 }, "model": "item/custom/blue_energy_sword_blocking" },
+        { "predicate": { "custom_model_data": 2, "blocking": 0 }, "model": "item/custom/red_energy_sword" },
+        { "predicate": { "custom_model_data": 2, "blocking": 1 }, "model": "item/custom/red_energy_sword_blocking" },
+        { "predicate": { "custom_model_data": 3, "blocking": 0 }, "model": "item/custom/yellow_energy_sword" },
+        { "predicate": { "custom_model_data": 3, "blocking": 1 }, "model": "item/custom/yellow_energy_sword_blocking" },
+        { "predicate": { "custom_model_data": 4, "blocking": 0 }, "model": "item/custom/green_energy_sword" },
+        { "predicate": { "custom_model_data": 4, "blocking": 1 }, "model": "item/custom/green_energy_sword_blocking" },
+        { "predicate": { "custom_model_data": 5, "blocking": 0 }, "model": "item/custom/purple_energy_sword" },
+        { "predicate": { "custom_model_data": 5, "blocking": 1 }, "model": "item/custom/purple_energy_sword_blocking" },
+        { "predicate": { "custom_model_data": 6, "blocking": 0 }, "model": "item/custom/orange_energy_sword" },
+        { "predicate": { "custom_model_data": 6, "blocking": 1 }, "model": "item/custom/orange_energy_sword_blocking" }
+    ]
+}

--- a/assets/minecraft/models/item/shield_blocking.json
+++ b/assets/minecraft/models/item/shield_blocking.json
@@ -1,0 +1,33 @@
+{
+    "parent": "builtin/entity",
+    "textures": {
+        "particle": "block/dark_oak_planks"
+    },
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [ 45, 135, 0 ],
+            "translation": [ 3.51, 11, -2 ],
+            "scale": [ 1, 1, 1 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ 45, 135, 0 ],
+            "translation": [ 13.51, 3, 5 ],
+            "scale": [ 1, 1, 1 ]
+        },
+        "firstperson_righthand": {
+            "rotation": [ 0, 180, -5 ],
+            "translation": [ -15, 5, -11 ],
+            "scale": [ 1.25, 1.25, 1.25 ]
+        },
+        "firstperson_lefthand": {
+            "rotation": [ 0, 180, -5 ],
+            "translation": [ 5, 5, -11 ],
+            "scale": [ 1.25, 1.25, 1.25 ]
+        },
+        "gui": {
+            "rotation": [ 15, -25, -5 ],
+            "translation": [ 2, 3, 0 ],
+            "scale": [ 0.65, 0.65, 0.65 ]
+        }
+    }
+}

--- a/assets/minecraft/models/item/snowball.json
+++ b/assets/minecraft/models/item/snowball.json
@@ -1,0 +1,17 @@
+{
+    "parent": "item/generated",
+    "textures": {
+        "layer0": "item/snowball"
+    },
+    "overrides": [
+        { "predicate": { "custom_model_data": 1 }, "model": "item/custom/empty_gas_canister" },
+        { "predicate": { "custom_model_data": 2 }, "model": "item/custom/helium_gas_canister" },
+        { "predicate": { "custom_model_data": 3 }, "model": "item/custom/oxygen_gas_canister" },
+        { "predicate": { "custom_model_data": 4 }, "model": "item/custom/hydrogen_gas_canister" },
+        { "predicate": { "custom_model_data": 5 }, "model": "item/custom/nitrogen_gas_canister" },
+        { "predicate": { "custom_model_data": 6 }, "model": "item/custom/carbon_dioxide_gas_canister" },
+        { "predicate": { "custom_model_data": 7 }, "model": "item/custom/battery_a" },
+        { "predicate": { "custom_model_data": 8 }, "model": "item/custom/battery_m" },
+        { "predicate": { "custom_model_data": 9 }, "model": "item/custom/battery_g" }
+    ]
+}


### PR DESCRIPTION
This PR does not contain any textures, just the files required for the server's custom blocks and items. Textures should be named as follows:

Block textures should go in \textures\block\custom

- aluminum_block
- aluminum_ore
- chetherite_block
- chetherite_ore
- titanium_block
- titanium_ore
- uranium_block
- uranium_ore

Item textures should go in \textures\item\custom

- battery_a
- battery_m
- battery_g
- pistol
- rifle
- sniper
- cannon
- blue_energy_sword
- green_energy_sword
- orange_energy_sword
- purple_energy_sword
- red_energy_sword
- yellow_energy_sword
- empty_gas_canister
- carbon_dioxide_gas_canister
- helium_gas_canister
- hydrogen_gas_canister
- nitrogen_gas_canister
- oxygen_gas_canister
- detonator
- aluminum
- chetherite
- titanium
- uranium
- power_drill
- shock_absorbing_module (currently disabled in server code)
- speed_boosting_module
- rocket_boosting_module
- night_vision_module
- environment_module
- pressure_field_module