### PR TITLE
Change note block top/bottom faces to iron block texture

### DIFF
--- a/assets/minecraft/models/block/note_block.json
+++ b/assets/minecraft/models/block/note_block.json
@@ -1,0 +1,12 @@
+{
+  "parent": "minecraft:block/cube",
+  "textures": {
+    "particle": "minecraft:block/iron_block",
+    "north": "minecraft:block/note_block",
+    "south": "minecraft:block/note_block",
+    "east": "minecraft:block/note_block",
+    "west": "minecraft:block/note_block",
+    "up": "minecraft:block/iron_block",
+    "down": "minecraft:block/iron_block"
+  }
+}


### PR DESCRIPTION
The top and bottom of note blocks aren't visible in most multiblocks.  In the ones that they are visible (T2, T3, T4 hyperdrive, powerbank), there is a block of glass on top that would obstruct access to the screen/controls on top- logically, there shouldn't be a screen/controls there.
![2022-04-16_01 02 27](https://user-images.githubusercontent.com/7875618/163662255-2f322b8b-22b9-4514-8ef2-f03e4910e3bb.png)
.