### PR TITLE
Fix redstone block/furnace overlay

### DIFF
--- a/assets/minecraft/optifine/ctm/redstone_block/redstone_block.properties
+++ b/assets/minecraft/optifine/ctm/redstone_block/redstone_block.properties
@@ -3,3 +3,4 @@ method=overlay
 tiles=1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
 connectBlocks=furnace
 layer=cutout
+weight=0

--- a/assets/minecraft/optifine/ctm/redstone_block/redstone_block2.properties
+++ b/assets/minecraft/optifine/ctm/redstone_block/redstone_block2.properties
@@ -2,3 +2,4 @@ matchBlocks=redstone_block
 method=ctm
 tiles=0 2 2 2 1 1 1 2 1 1 1 1 1 2 2 2 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 2 2 2 1 1 1 1 1 1 1
 connect=block
+weight=1

--- a/assets/minecraft/optifine/ctm/redstone_block/redstone_block3.properties
+++ b/assets/minecraft/optifine/ctm/redstone_block/redstone_block3.properties
@@ -2,3 +2,4 @@ matchBlocks=redstone_block
 method=ctm
 tiles=2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 connectBlocks=redstone_block
+weight=1


### PR DESCRIPTION
Fixes redstone block connected texture orientation when next to a furnace, as seen on HLs:
![2022-05-08_00 08 41](https://user-images.githubusercontent.com/7875618/167281426-f2f52c8a-854d-4463-90a5-551f849b573e.png)
